### PR TITLE
Use bootstrap instead of registerCertificate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,12 @@ repositories {
 dependencies {
     implementation group: 'com.google.inject', name: 'guice', version: '5.0.1'
     implementation group: 'com.scalar-labs', name: 'kelpie', version: '1.2.3'
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.10.0'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.13.0'
     implementation group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '1.3.1'
 }
 
 shadowJar {
+    zip64 = true
     mergeServiceFiles()
     exclude 'com/scalar/dl/benchmarks/smallbank/contract/*'
     exclude 'com/scalar/dl/benchmarks/tpcc/contract/*'

--- a/src/main/java/com/scalar/dl/benchmarks/smallbank/SmallBankLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/smallbank/SmallBankLoader.java
@@ -99,7 +99,7 @@ public class SmallBankLoader extends PreProcessor {
   }
 
   private void registerCertificateAndContracts() {
-    service.registerCertificate();
+    service.bootstrap();
     service.registerContract(createContractId, createContractName, createContractPath);
     service.registerContract(balanceContractId, balanceContractName, balanceContractPath);
     service.registerContract(savingContractId, savingContractName, savingContractPath);

--- a/src/main/java/com/scalar/dl/benchmarks/smallbank/SmallBankLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/smallbank/SmallBankLoader.java
@@ -89,7 +89,7 @@ public class SmallBankLoader extends PreProcessor {
 
   @Override
   public void execute() {
-    registerCertificateAndContracts();
+    bootstrapAndRegisterContracts();
     loadRecords();
   }
 
@@ -98,7 +98,7 @@ public class SmallBankLoader extends PreProcessor {
     factory.close();
   }
 
-  private void registerCertificateAndContracts() {
+  private void bootstrapAndRegisterContracts() {
     service.bootstrap();
     service.registerContract(createContractId, createContractName, createContractPath);
     service.registerContract(balanceContractId, balanceContractName, balanceContractPath);

--- a/src/main/java/com/scalar/dl/benchmarks/tpcc/TpccLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/tpcc/TpccLoader.java
@@ -122,7 +122,7 @@ public class TpccLoader extends PreProcessor {
   }
 
   private void registerCertificateAndContracts() {
-    service.registerCertificate();
+    service.bootstrap();
     service.registerContract(loaderContractId, loaderContractName, loaderContractPath);
     service.registerContract(newOrderContractId, newOrderContractName, newOrderContractPath);
     service.registerContract(paymentContractId, paymentContractName, paymentContractPath);

--- a/src/main/java/com/scalar/dl/benchmarks/tpcc/TpccLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/tpcc/TpccLoader.java
@@ -112,7 +112,7 @@ public class TpccLoader extends PreProcessor {
 
   @Override
   public void execute() {
-    registerCertificateAndContracts();
+    bootstrapAndRegisterContracts();
     loadRecords();
   }
 
@@ -121,7 +121,7 @@ public class TpccLoader extends PreProcessor {
     factory.close();
   }
 
-  private void registerCertificateAndContracts() {
+  private void bootstrapAndRegisterContracts() {
     service.bootstrap();
     service.registerContract(loaderContractId, loaderContractName, loaderContractPath);
     service.registerContract(newOrderContractId, newOrderContractName, newOrderContractPath);

--- a/src/main/java/com/scalar/dl/benchmarks/ycsb/YcsbLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/ycsb/YcsbLoader.java
@@ -73,7 +73,7 @@ public class YcsbLoader extends PreProcessor {
 
   @Override
   public void execute() {
-    registerCertificateAndContracts();
+    bootstrapAndRegisterContracts();
     loadRecords();
   }
 
@@ -82,7 +82,7 @@ public class YcsbLoader extends PreProcessor {
     factory.close();
   }
 
-  private void registerCertificateAndContracts() {
+  private void bootstrapAndRegisterContracts() {
     service.bootstrap();
     service.registerContract(createContractId, createContractName, createContractPath);
     service.registerContract(workloadAContractId, workloadAContractName, workloadAContractPath);

--- a/src/main/java/com/scalar/dl/benchmarks/ycsb/YcsbLoader.java
+++ b/src/main/java/com/scalar/dl/benchmarks/ycsb/YcsbLoader.java
@@ -83,7 +83,7 @@ public class YcsbLoader extends PreProcessor {
   }
 
   private void registerCertificateAndContracts() {
-    service.registerCertificate();
+    service.bootstrap();
     service.registerContract(createContractId, createContractName, createContractPath);
     service.registerContract(workloadAContractId, workloadAContractName, workloadAContractPath);
     service.registerContract(workloadCContractId, workloadCContractName, workloadCContractPath);


### PR DESCRIPTION
## Description

This PR updates loaders to use `bootstrap`.

Since the previous code uses `registerCertificate`, we cannot try HMAC authentication mode without code changes. To address this issue, this PR updates the loader code to use `bootstrap`, which handles both the digital signature and the HMAC authentication.

## Related issues and/or PRs

- N/A

## Changes made

- Updated loaders to use `bootstrap` instead of `registerCertificate`.
- Updated the client SDK version to v3.13.0.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A